### PR TITLE
Don't include .txt files in the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 """Integrates dogpile.cache for Pyramid
 """
 from setuptools import setup, find_packages
-import glob
 import os.path
 
 
@@ -48,6 +47,5 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
-    data_files=[('', glob.glob(project_path('*.txt')))],
     zip_safe=False,
 )


### PR DESCRIPTION
This patch removes the `*.txt` glob from `setup.py` because it breaks with recent setuptools/wheel and was only used for `CHANGES.txt`:

```
Building wheels for collected packages: pyramid-dogpile-cache2
  Running setup.py bdist_wheel for pyramid-dogpile-cache2 ... error
  Complete output from command /Users/andy/.virtualenvs/tmp-c9d4acdfc52d4197/bin/python2.7 -u -c "import setuptools, tokenize;__file__='/private/var/folders/bw/ghklm2fs6bx_x9x_f0wg5kph0000gn/T/pip-9EX423-build/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /var/folders/bw/ghklm2fs6bx_x9x_f0wg5kph0000gn/T/tmpkwPEjapip-wheel-:
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib
  creating build/lib/pyramid_dogpile_cache2
  copying src/pyramid_dogpile_cache2/__init__.py -> build/lib/pyramid_dogpile_cache2
  copying src/pyramid_dogpile_cache2/cache.py -> build/lib/pyramid_dogpile_cache2
  creating build/lib/pyramid_dogpile_cache2/tests
  copying src/pyramid_dogpile_cache2/tests/__init__.py -> build/lib/pyramid_dogpile_cache2/tests
  copying src/pyramid_dogpile_cache2/tests/conftest.py -> build/lib/pyramid_dogpile_cache2/tests
  copying src/pyramid_dogpile_cache2/tests/test_cache.py -> build/lib/pyramid_dogpile_cache2/tests
  copying src/pyramid_dogpile_cache2/tests/test_configuration.py -> build/lib/pyramid_dogpile_cache2/tests
  running egg_info
  creating src/pyramid_dogpile_cache2.egg-info
  writing requirements to src/pyramid_dogpile_cache2.egg-info/requires.txt
  writing src/pyramid_dogpile_cache2.egg-info/PKG-INFO
  writing top-level names to src/pyramid_dogpile_cache2.egg-info/top_level.txt
  writing dependency_links to src/pyramid_dogpile_cache2.egg-info/dependency_links.txt
  writing manifest file 'src/pyramid_dogpile_cache2.egg-info/SOURCES.txt'
  reading manifest file 'src/pyramid_dogpile_cache2.egg-info/SOURCES.txt'
  writing manifest file 'src/pyramid_dogpile_cache2.egg-info/SOURCES.txt'
  error: Error: setup script specifies an absolute path:

      /private/var/folders/bw/ghklm2fs6bx_x9x_f0wg5kph0000gn/T/pip-9EX423-build/CHANGES.txt

  setup() arguments must *always* be /-separated paths relative to the
  setup.py directory, *never* absolute paths.
```