### PR TITLE
Support caching functions with type annotations on Python 3

### DIFF
--- a/src/pyramid_dogpile_cache2/cache.py
+++ b/src/pyramid_dogpile_cache2/cache.py
@@ -8,7 +8,10 @@ def key_generator(ns, fn, to_str=dogpile.util.compat.text_type):
     non-ascii function arguments, and supports not just plain functions, but
     methods as well.
     """
-    args = inspect.getargspec(fn)
+    if dogpile.util.compat.py2k:
+        args = inspect.getargspec(fn)
+    else:
+        args = inspect.getfullargspec(fn)
     has_self = args[0] and args[0][0] in ('self', 'cls')
 
     def generate_key(*args, **kw):

--- a/src/pyramid_dogpile_cache2/tests/test_cache_py3.py
+++ b/src/pyramid_dogpile_cache2/tests/test_cache_py3.py
@@ -1,0 +1,14 @@
+import dogpile.cache.util
+import pyramid_dogpile_cache2.cache
+import pytest
+
+
+@pytest.mark.skipif(
+    dogpile.util.compat.py2k,
+    reason='Python 2 does not support type annotation syntax')
+def test_key_generator_handles_type_annotations():
+    def function_with_annotations() -> None:
+        pass
+
+    gen = pyramid_dogpile_cache2.cache.key_generator(None, function_with_annotations)
+    assert gen() == 'pyramid_dogpile_cache2.tests.test_cache_py3.function_with_annotations|'

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,7 @@ minversion = 1.6
 deps =
     pytest
     pytest-cov
+setenv =
+    py27: PYTEST_ADDOPTS=--ignore {toxinidir}/src/pyramid_dogpile_cache2/tests/test_cache_py3.py
 commands = py.test --tb=native {toxinidir}/src
 usedevelop = True


### PR DESCRIPTION
Fixes #4.