### PR TITLE
configure_dogpile_cache: pop actual_backend to prevent stale cache

### DIFF
--- a/src/pyramid_dogpile_cache2/__init__.py
+++ b/src/pyramid_dogpile_cache2/__init__.py
@@ -64,6 +64,8 @@ def configure_dogpile_cache(settings):
         # configure_dogpile_cache() may be called multiple times (which
         # should only happen in tests).
         region.__dict__.pop('backend', None)
+        # Pop cached actual_backend value as well (to prevent cache mismatch)
+        region.__dict__.pop('_actual_backend', None)
         region.configure_from_config(settings, prefix='')
 
     # Since get_region() returns an unconfigured region for *any* name you

--- a/src/pyramid_dogpile_cache2/tests/test_configuration.py
+++ b/src/pyramid_dogpile_cache2/tests/test_configuration.py
@@ -70,3 +70,34 @@ def test_unconfigured_region_raises(empty_config):
             'dogpile_cache.backend': 'dogpile.cache.memory',
             'dogpile_cache.expiration_time': '1',
         })
+
+
+def test_multiple_calls_clear_backend(empty_config):
+    configure_dogpile_cache({
+        'dogpile_cache.regions': 'foo',
+        'dogpile_cache.backend': 'dogpile.cache.memory',
+        'dogpile_cache.expiration_time': '1',
+    })
+
+    region = get_region('foo')
+
+    # Init cached value in region
+    _ = region.actual_backend
+
+    original_backend = region.backend
+    assert region.actual_backend == original_backend
+
+    configure_dogpile_cache({
+        'dogpile_cache.regions': 'foo',
+        'dogpile_cache.backend': 'dogpile.cache.memory',
+        'dogpile_cache.expiration_time': '1',
+    })
+
+    # Confirm region is back to fresh state
+    new_backend = region.backend
+    assert new_backend != original_backend
+    assert region._actual_backend is None
+
+    # Regen cached value. Confirm cache points to new backend
+    _ = region.actual_backend
+    assert region.actual_backend == new_backend


### PR DESCRIPTION
https://github.com/sqlalchemy/dogpile.cache/commit/ccfa1ba962bdf2987c922e6393ac9859487f510c

4 years ago, actual_backend attribute was introduced.

Updating configure_dogpile_cache to handle this value (avoids
nasty cache bugs if one were to call actual_backend in code)